### PR TITLE
Fix quoting for FINAL_CMD

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ fi
 # fi
 
 # Build final command
-FINAL_CMD="$CMD $*"
+FINAL_CMD="$CMD \"$@\""
 
 # Show the final command (for debugging)
 echo "[ENTRYPOINT] Final command: $FINAL_CMD"


### PR DESCRIPTION
## Summary
- preserve quoted arguments passed to `entrypoint.sh`

## Testing
- `shellcheck entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_688223915ec88332b8998a1c19e4e797