### PR TITLE
Fix entrypoint argument handling

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,10 +9,13 @@ CMD="/usr/local/bin/litellm"
 
 echo "[ENTRYPOINT] Preparing command..."
 
+# Start with base command and user arguments
+set -- "$CMD" "$@"
+
 # Add --config option if LITELLM_CONFIG is set and valid
 if [ -n "$LITELLM_CONFIG" ] && [ -f "$LITELLM_CONFIG" ] && [ -s "$LITELLM_CONFIG" ]; then
     echo "[ENTRYPOINT] Using config: $LITELLM_CONFIG"
-    CMD="$CMD --config \"$LITELLM_CONFIG\""
+    set -- "$1" --config "$LITELLM_CONFIG" "${@:2}"
 else
     echo "[ENTRYPOINT] No valid config file found or LITELLM_CONFIG not set."
 fi
@@ -25,10 +28,10 @@ fi
 # fi
 
 # Build final command
-FINAL_CMD="$CMD $*"
+FINAL_CMD="$*"
 
 # Show the final command (for debugging)
 echo "[ENTRYPOINT] Final command: $FINAL_CMD"
 
 # Execute the command
-exec sh -c "$FINAL_CMD"
+exec "$@"


### PR DESCRIPTION
## Summary
- fix quoting issue in entrypoint script by rebuilding argument list

## Testing
- `shellcheck entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_6881f407595883328ed919ea0c5fdebe