### PR TITLE
Add ConfigMap for env vars in helm chart

### DIFF
--- a/chart/llm-gw/Chart.yaml
+++ b/chart/llm-gw/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/llm-gw/templates/configmap.yaml
+++ b/chart/llm-gw/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-env
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+data:
+{{- range $key, $val := .Values.env }}
+  {{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
+

--- a/chart/llm-gw/templates/deployment.yaml
+++ b/chart/llm-gw/templates/deployment.yaml
@@ -91,3 +91,8 @@ spec:
           {{- else if ne .Values.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
           {{- end }}
+          {{- if .Values.env }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "common.names.fullname" . }}-env
+          {{- end }}

--- a/chart/llm-gw/values.yaml
+++ b/chart/llm-gw/values.yaml
@@ -31,3 +31,6 @@ nodeAffinityPreset:
 
 
 resourcesPreset: "none"
+
+# Environment variables to be injected via ConfigMap
+env: {}


### PR DESCRIPTION
## Summary
- add configmap template to hold environment variables
- inject configmap into Deployment when `env` values are provided
- expose `env` in `values.yaml`
- bump chart version to 0.1.1

## Testing
- `helm template test chart/llm-gw`
- `helm template test chart/llm-gw --set env.TEST=abc`

------
https://chatgpt.com/codex/tasks/task_b_6882256f51a083329018078539d329a0