### PR TITLE
Tie service port to env variable

### DIFF
--- a/chart/llm-gw/Chart.yaml
+++ b/chart/llm-gw/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/llm-gw/templates/deployment.yaml
+++ b/chart/llm-gw/templates/deployment.yaml
@@ -91,6 +91,9 @@ spec:
           {{- else if ne .Values.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
           {{- end }}
+          ports:
+            - containerPort: {{ .Values.env.PORT }}
+              name: http
           {{- if .Values.env }}
           envFrom:
             - configMapRef:

--- a/chart/llm-gw/templates/service.yaml
+++ b/chart/llm-gw/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.env.PORT }}
+      protocol: TCP
+      name: http
+  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}

--- a/chart/llm-gw/values.yaml
+++ b/chart/llm-gw/values.yaml
@@ -10,6 +10,10 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
+service:
+  type: ClusterIP
+  port: 80
+
 podSecurityContext:
   enabled: false
   fsGroup: 1001
@@ -33,4 +37,5 @@ nodeAffinityPreset:
 resourcesPreset: "none"
 
 # Environment variables to be injected via ConfigMap
-env: {}
+env:
+  PORT: 4000


### PR DESCRIPTION
## Summary
- keep chart version 0.0.2
- use `.Values.env.PORT` for container and service port
- revert entrypoint script and unit test

## Testing
- `bash -x tests/test_entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_b_68822c8a69d88332b8d1edb859adf85f