### PR TITLE
Add reusable Docker build workflow

### DIFF
--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -1,0 +1,63 @@
+name: Reusable Docker Build
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        description: Docker registry
+        required: false
+        type: string
+        default: docker.io
+      namespace:
+        description: Registry namespace/username
+        required: true
+        type: string
+      image:
+        description: Docker image name
+        required: true
+        type: string
+    secrets:
+      DH_TOKEN:
+        description: Docker registry token
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      registry: ${{ inputs.registry }}
+      namespace: ${{ inputs.namespace }}
+      image: ${{ inputs.image }}
+      digest: ${{ steps.docker_builder.outputs.digest }}
+      tags: ${{ steps.docker_metadata.outputs.tags }}
+    steps:
+      - name: Docker Metadata
+        id: docker_metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ inputs.namespace }}/${{ inputs.image }},enable=true
+          tags: |
+            type=ref,event=tag
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Hub Login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ inputs.namespace }}
+          password: ${{ secrets.DH_TOKEN }}
+
+      - name: Docker Build and Push
+        id: docker_builder
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.docker_metadata.outputs.tags }}


### PR DESCRIPTION
## Summary
- create reusable GitHub workflow to build and push Docker image

## Testing
- `bash tests/test_entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_68822cf93104833298e819786fdddbab