### PR TITLE
Add on-call provenance workflow

### DIFF
--- a/.github/workflows/oncall-provenance.yaml
+++ b/.github/workflows/oncall-provenance.yaml
@@ -1,0 +1,87 @@
+name: On-call Provenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      registry:
+        description: Docker registry
+        required: false
+        default: docker.io
+        type: string
+      namespace:
+        description: Registry namespace/username
+        required: true
+        type: string
+      image:
+        description: Docker image name
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      registry:
+        description: Docker registry
+        required: false
+        type: string
+        default: docker.io
+      namespace:
+        description: Registry namespace/username
+        required: true
+        type: string
+      image:
+        description: Docker image name
+        required: true
+        type: string
+    secrets:
+      DH_TOKEN:
+        required: true
+    outputs:
+      registry:
+        description: Docker registry
+        value: ${{ jobs.build.outputs.registry }}
+      namespace:
+        description: Registry namespace/username
+        value: ${{ jobs.build.outputs.namespace }}
+      image:
+        description: Docker image name
+        value: ${{ jobs.build.outputs.image }}
+      digest:
+        description: Image digest
+        value: ${{ jobs.build.outputs.digest }}
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+    with:
+      registry: ${{ inputs.registry }}
+      namespace: ${{ inputs.namespace }}
+      image: ${{ inputs.image }}
+    secrets:
+      DH_TOKEN: ${{ secrets.DH_TOKEN }}
+
+  provenance:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    env:
+      registry: ${{ needs.build.outputs.registry }}
+      namespace: ${{ needs.build.outputs.namespace }}
+      image: ${{ needs.build.outputs.image }}
+      digest: ${{ needs.build.outputs.digest }}
+    steps:
+      - name: Docker Hub Login
+        id: registry_login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.namespace }}
+          password: ${{ secrets.DH_TOKEN }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.registry }}/${{ env.namespace }}/${{ env.image }}
+          subject-digest: ${{ env.digest }}
+          push-to-registry: true
+


### PR DESCRIPTION
## Summary
- add new workflow `oncall-provenance.yaml` triggered manually or as a reusable workflow
- define inputs for registry, namespace and image and expose build outputs

## Testing
- `bash tests/test_entrypoint.sh && echo "tests passed"`


------
https://chatgpt.com/codex/tasks/task_b_6883317bac188332890aefa17757ed2d