### PR TITLE
Update release workflow to reuse provenance job

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -17,29 +17,13 @@ jobs:
   provenance:
     needs:
       - build
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      attestations: write
-    env:
+    uses: ./.github/workflows/provenance.yaml
+    with:
       registry: ${{ needs.build.outputs.registry }}
       namespace: ${{ needs.build.outputs.namespace }}
       image: ${{ needs.build.outputs.image }}
-      digest: ${{ needs.build.outputs.digest }}
-    steps:
-      - name: Docker Hub Login
-        id: registry_login
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.namespace }}
-          password: ${{ secrets.DH_TOKEN }}
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.registry }}/${{ env.namespace }}/${{ env.image }}
-          subject-digest: ${{ env.digest }}
-          push-to-registry: true
+    secrets:
+      DH_TOKEN: ${{ secrets.DH_TOKEN }}
 
   sbom:
     needs:


### PR DESCRIPTION
## Summary
- reduce duplication by calling the reusable `provenance.yaml` workflow in the release workflow

## Testing
- `bash tests/test_entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_68835d300c008332be3d0648c97e2d88