### PR TITLE
Fix release workflow provenance call

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -18,10 +18,14 @@ jobs:
     needs:
       - build
     uses: ./.github/workflows/provenance.yaml
+    permissions:
+      id-token: write
+      attestations: write
     with:
       registry: ${{ needs.build.outputs.registry }}
       namespace: ${{ needs.build.outputs.namespace }}
       image: ${{ needs.build.outputs.image }}
+      digest: ${{ needs.build.outputs.digest }}
     secrets:
       DH_TOKEN: ${{ secrets.DH_TOKEN }}
 


### PR DESCRIPTION
## Summary
- pass the image digest to the provenance workflow
- allow the called workflow to write attestations and use OIDC tokens

## Testing
- `bash tests/test_entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_6883602478b083329dabd1dc0fab7e58