### PR TITLE
Fix workflow secret collision

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -40,7 +40,6 @@ jobs:
       digest: ${{ needs.build.outputs.digest }}
     secrets:
       DH_TOKEN: ${{ secrets.DH_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   sign:
     needs:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -33,9 +33,6 @@ on:
       DH_TOKEN:
         description: Docker registry token
         required: true
-      GITHUB_TOKEN:
-        description: GitHub token
-        required: true
     outputs:
       sbom-path:
         description: Path to generated SBOM file
@@ -93,6 +90,6 @@ jobs:
 
       - name: Upload SBOM to GitHub
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh release upload ${{ inputs.tag }} ./sbom.spdx.json


### PR DESCRIPTION
## Summary
- remove `GITHUB_TOKEN` from the reusable `sbom` workflow call
- rely on builtin GitHub token in sbom upload step

## Testing
- `bash tests/test_entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_688361c901cc8332918663b63da97868