### PR TITLE
Add on-call sign workflow

### DIFF
--- a/.github/workflows/sign.yaml
+++ b/.github/workflows/sign.yaml
@@ -1,0 +1,78 @@
+name: On-call Sign
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: Registry namespace/username
+        required: true
+        type: string
+      digest:
+        description: Image digest
+        required: true
+        type: string
+      tags:
+        description: Space separated image tags
+        required: true
+        type: string
+      cosign-release:
+        description: Cosign release version
+        required: false
+        default: 'v2.5.3'
+        type: string
+  workflow_call:
+    inputs:
+      namespace:
+        description: Registry namespace/username
+        required: true
+        type: string
+      digest:
+        description: Image digest
+        required: true
+        type: string
+      tags:
+        description: Space separated image tags
+        required: true
+        type: string
+      cosign-release:
+        description: Cosign release version
+        required: false
+        default: 'v2.5.3'
+        type: string
+    secrets:
+      DH_TOKEN:
+        required: true
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      cosign-release: ${{ inputs['cosign-release'] }}
+      namespace: ${{ inputs.namespace }}
+      digest: ${{ inputs.digest }}
+      tags: ${{ inputs.tags }}
+    steps:
+      - name: Docker Hub Login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.namespace }}
+          password: ${{ secrets.DH_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: ${{ env.cosign-release }}
+
+      - name: Sign the images with GitHub OIDC Token
+        env:
+          DIGEST: ${{ env.digest }}
+          TAGS: ${{ env.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+


### PR DESCRIPTION
## Summary
- extract sign job into a dedicated workflow triggered manually or via `workflow_call`

## Testing
- `bash tests/test_entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_6883658d7bcc8332a6ca04136e7e792a