### PR TITLE
Add Helm chart to release workflow

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -58,3 +58,18 @@ jobs:
       tags: ${{ needs.build.outputs.tags }}
     secrets:
       DH_TOKEN: ${{ secrets.DH_TOKEN }}
+
+  chart:
+    needs:
+      - sign
+    uses: ./.github/workflows/chart-publish.yaml
+    permissions:
+      contents: write
+    with:
+      namespace: ${{ needs.build.outputs.namespace }}
+      repository: llm-gw-chart
+      chart_path: chart/llm-gw
+      registry: registry-1.docker.io
+      tag: ${{ github.event.release.tag_name }}
+    secrets:
+      DH_TOKEN: ${{ secrets.DH_TOKEN }}


### PR DESCRIPTION
## Summary
- publish Helm chart during release workflow

## Testing
- `bash tests/test_entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_688368995a2c8332b7e07e168f3a2ffb